### PR TITLE
add support for progressive JPEG emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ With all this internet going around, sometimes you just want to experience the t
     * **randLoadIncrement** Set to true to make load increment random, loadIncrement ignored in this case.
     * **loadIncrement** Number of pixels to load each time the loadSpeed timer ticks.
     * **randomPause** Probability of skipping a pass each time the loadSpeed timer ticks.
+    * **progressiveJPEG** Set to true to enable progressive JPEG emulation
 
 ## See it in action!
 See an example on the project's site at: http://theonion.github.io/comcastifyjs/

--- a/comcastify.js
+++ b/comcastify.js
@@ -72,6 +72,7 @@ var comcastifyjs = (function () {
     return function () {
 
       var params = {
+        elements: args.elements || document.querySelectorAll('img:not([class="progressiveJPEGemulator"])'), // elements affected
         boxColor: args.boxColor || '#000000',                 // color of box overlay
         loadMaxPercent: args.loadMaxPercent || 0.0,           // max percentage to load images
         loadSpeed: args.loadSpeed || 500,                     // how often in ms to pass
@@ -80,14 +81,6 @@ var comcastifyjs = (function () {
         randomPause: args.randomPause || 0.0,                 // probability of skipping a pass
         progressiveJPEG: args.progressiveJPEG || false        // enable progressive JPEG emulation
       };
-
-      // generate a list of effected elements based on progressiveJPEG argument
-      if (params.progressiveJPEG) {
-        // this branch doesn't generate a live HTMLCollection, so images added after page load will not automatically load at Comcast speeds
-        params.elements = args.elements || document.querySelectorAll('img:not([class="progessiveJPEGemulator"])');
-      } else {
-        params.elements = args.elements || document.getElementsByTagName('img');
-      }
 
       // make 'em load slow
       for(var i = 0; i < params.elements.length; i++) {

--- a/comcastify.js
+++ b/comcastify.js
@@ -7,6 +7,7 @@ var comcastifyjs = (function () {
         // calculate new height for box based on args
         var img = slowloadDiv.slothifyData.img;
         var newTopClip = slowloadDiv.slothifyData.imageTopClip + args.loadIncrement;
+        var progressiveJPEGInProgress = false;
         if (args.randomPause === 0.0 || Math.random() > args.randomPause) {
           slowloadDiv.style.width = img.offsetWidth + 'px';
           slowloadDiv.style.height = img.offsetHeight + 'px';
@@ -20,11 +21,36 @@ var comcastifyjs = (function () {
           var maxImageHeight = img.height * args.loadMaxPercent;
         }
 
+        //process progressive JPEG unblurring
+        if (args.progressiveJPEG && newTopClip >= maxImageHeight) {
+          var newTopClipBlur = slowloadDiv.slothifyData.blurImageTopClip + args.loadIncrement;
+
+          //continue to honor the randomPause setting
+          if (args.randomPause === 0.0 || Math.random() > args.randomPause) {
+            slowloadDiv.slothifyData.blurImg.style.width = img.offsetWidth + 'px';
+            slowloadDiv.slothifyData.blurImg.style.height = img.offsetHeight + 'px';
+            slowloadDiv.slothifyData.blurImg.style.top = img.offsetTop + 'px';
+            slowloadDiv.slothifyData.blurImg.style.left = img.offsetLeft + 'px';
+
+            // update slowload div
+            slowloadDiv.slothifyData.blurImg.style.clip = 'rect(' + newTopClipBlur + 'px auto auto auto)';
+
+            slowloadDiv.slothifyData.blurImageTopClip = newTopClipBlur;
+          }
+
+          // check stopping conditions
+          var maxImageHeightBlur = img.height * args.loadMaxPercent;
+
+          if (newTopClipBlur < maxImageHeightBlur) {
+            progressiveJPEGInProgress = true;
+          }
+        }
+
         if (!img.complete) {
           setTimeout(slowloadModiferCallback(slowloadDiv, args), args.loadSpeed);
         } else if (typeof img.naturalHeight !== "undefined" && img.naturalWidth === 0) {
           setTimeout(slowloadModiferCallback(slowloadDiv, args), args.loadSpeed);
-        } else if (!maxImageHeight || maxImageHeight === 0 || newTopClip < maxImageHeight) {
+        } else if (!maxImageHeight || maxImageHeight === 0 || newTopClip < maxImageHeight || progressiveJPEGInProgress) {
           // create new update timeout
           slowloadDiv.slothifyData.imageTopClip = newTopClip;
           setTimeout(slowloadModiferCallback(slowloadDiv, args), args.loadSpeed);
@@ -46,14 +72,22 @@ var comcastifyjs = (function () {
     return function () {
 
       var params = {
-        elements: args.elements || document.getElementsByTagName('img'),  // elements affected
         boxColor: args.boxColor || '#000000',                 // color of box overlay
         loadMaxPercent: args.loadMaxPercent || 0.0,           // max percentage to load images
         loadSpeed: args.loadSpeed || 500,                     // how often in ms to pass
         randLoadIncrement: args.randLoadIncrement || false,   // true to randomize load increment
         loadIncrement: args.loadIncrement || 1,               // pixels to load per pass
-        randomPause: args.randomPause || 0.0                  // probability of skipping a pass
+        randomPause: args.randomPause || 0.0,                 // probability of skipping a pass
+        progressiveJPEG: args.progressiveJPEG || false        // enable progressive JPEG emulation
       };
+
+      // generate a list of effected elements based on progressiveJPEG argument
+      if (params.progressiveJPEG) {
+        // this branch doesn't generate a live HTMLCollection, so images added after page load will not automatically load at Comcast speeds
+        params.elements = args.elements || document.querySelectorAll('img:not([class="progessiveJPEGemulator"])');
+      } else {
+        params.elements = args.elements || document.getElementsByTagName('img');
+      }
 
       // make 'em load slow
       for(var i = 0; i < params.elements.length; i++) {
@@ -77,6 +111,31 @@ var comcastifyjs = (function () {
             imageTopClip: 0,
             maxImageHeight: img.height * params.loadMaxPercent
         };
+
+        // setup the blurred image for progressive JPEG if needed
+        if (params.progressiveJPEG === true) {
+          var progressiveJPEGdiv = document.createElement('DIV');
+          progressiveJPEGdiv.style.backgroundColor = params.boxColor;
+          progressiveJPEGdiv.style.width = img.offsetWidth + 'px';
+          progressiveJPEGdiv.style.height = img.offsetHeight + 'px';
+          progressiveJPEGdiv.style.position = 'absolute';
+          progressiveJPEGdiv.style.top = img.offsetTop + 'px';
+          progressiveJPEGdiv.style.left = img.offsetLeft + 'px';
+          progressiveJPEGdiv.style.clip = 'rect(0 auto auto auto)';
+          progressiveJPEGdiv.style.overflow = 'hidden';
+
+          var progressiveJPEGimg = document.createElement('IMG');
+          progressiveJPEGimg.setAttribute('class','progressiveJPEGemulator');
+          progressiveJPEGimg.setAttribute('src',img.src);
+          progressiveJPEGimg.setAttribute('style','margin: -2px 0 0 0; -webkit-filter: blur(5px); -moz-filter: blur(5px); -o-filter: blur(5px); -ms-filter: blur(5px); filter: blur(5px);'); 
+          progressiveJPEGimg.setAttribute('width', progressiveJPEGdiv.style.width);
+          progressiveJPEGimg.setAttribute('height', progressiveJPEGdiv.style.height);
+          progressiveJPEGdiv.appendChild(progressiveJPEGimg);
+          parent.appendChild(progressiveJPEGdiv);
+
+          slowload.slothifyData.blurImg = progressiveJPEGdiv;
+          slowload.slothifyData.blurImageTopClip = 0;
+        }
 
         // put box over image
         parent.appendChild(slowload);

--- a/example/example-progressivejpeg.html
+++ b/example/example-progressivejpeg.html
@@ -1,0 +1,42 @@
+<html>
+    <head>
+        
+        <title>comcastify.js - Sometimes images just load too damned fast!</title>
+
+    </head>
+
+    <body>
+
+        <div style="width: 100px; display: inline-block;">
+            <img style="width:100%" src="baby-sloth.jpg" alt="http://violetadams.deviantart.com/art/Baby-sloth-385183627" />
+        </div>
+
+        <div style="width: 100px; display: inline-block;">
+            <image style="width: 100%" src="sloth-close-up.jpg" alt="http://mashable.com/2013/07/20/sloth-makeover/" />
+        </div>
+
+        <div style="width: 100px; display: inline-block;">
+            <image style="width: 100%" src="sloth-hanging.jpg" alt="http://mashable.com/2013/07/20/sloth-makeover/" />
+        </div>
+
+        <div>
+            <img src="sloth.jpg" alt="http://www.wisegeek.com/what-are-the-main-components-of-a-sloth-diet.htm#sloth-in-tree-showing-claws" />
+        </div>
+
+        <script type="text/javascript" src="../comcastify.js"></script>
+        <script type="text/javascript">
+
+            window.onload = comcastifyjs.fixMyImagesLoadingSoFast({
+                boxColor: '#123456', //looks the most like a progressive jpeg with white
+                loadMaxPercent: 1.0,
+                loadSpeed: 100,
+                randLoadIncrement: true,
+                randomPause: .3,
+                progressiveJPEG: true
+            });
+
+        </script>
+
+    </body>
+
+</html>


### PR DESCRIPTION
This adds support for Progressive JPEG emulation to add even more terribleness.  The only real issue with this setup is we can't pull the images via getElementsByTagName() since that gets a live collection that would grow infinitely each time a new blurred image is created.  I used querySelectorAll('img:not([class="progessiveJPEGemulator"])') instead only when the progressiveJPEG parameter is set to true.
