### PR TITLE
Added trailing commas at the end of objects.

### DIFF
--- a/comcastify.js
+++ b/comcastify.js
@@ -52,7 +52,7 @@ var comcastifyjs = (function () {
         loadSpeed: args.loadSpeed || 500,                     // how often in ms to pass
         randLoadIncrement: args.randLoadIncrement || false,   // true to randomize load increment
         loadIncrement: args.loadIncrement || 1,               // pixels to load per pass
-        randomPause: args.randomPause || 0.0                  // probability of skipping a pass
+        randomPause: args.randomPause || 0.0,                 // probability of skipping a pass
       };
 
       // make 'em load slow
@@ -75,7 +75,7 @@ var comcastifyjs = (function () {
         slowload.slothifyData = {
             img: img,
             imageTopClip: 0,
-            maxImageHeight: img.height * params.loadMaxPercent
+            maxImageHeight: img.height * params.loadMaxPercent,
         };
 
         // put box over image
@@ -102,7 +102,7 @@ var comcastifyjs = (function () {
 
   return {
     letsPrepareTheseImages: prepare,
-    fixMyImagesLoadingSoFast: slowImages
+    fixMyImagesLoadingSoFast: slowImages,
   };
 
 })();


### PR DESCRIPTION
Although trailing commas at the end of objects are typically frowned upon in OLDER IE browsers, they are perfectly acceptable in modern browsers.  Individuals using older versions of IE are most likely already fortunate enough to have Comcast as their internet provider, and therefore will not be using comcastifyjs.  Adding these trailing commas is simply proper syntax.
