### PR TITLE
Remove 'type="text/javascript"' in example <script> tags

### DIFF
--- a/example/example-random.html
+++ b/example/example-random.html
@@ -23,8 +23,8 @@
             <img src="sloth.jpg" alt="http://www.wisegeek.com/what-are-the-main-components-of-a-sloth-diet.htm#sloth-in-tree-showing-claws" />
         </div>
 
-        <script type="text/javascript" src="../comcastify.js"></script>
-        <script type="text/javascript">
+        <script src="../comcastify.js"></script>
+        <script>
 
             window.onload = comcastifyjs.fixMyImagesLoadingSoFast({
                 boxColor: '#123456',

--- a/example/example-randompause.html
+++ b/example/example-randompause.html
@@ -23,8 +23,8 @@
             <img src="sloth.jpg" alt="http://www.wisegeek.com/what-are-the-main-components-of-a-sloth-diet.htm#sloth-in-tree-showing-claws" />
         </div>
 
-        <script type="text/javascript" src="../comcastify.js"></script>
-        <script type="text/javascript">
+        <script src="../comcastify.js"></script>
+        <script>
 
             window.onload = comcastifyjs.fixMyImagesLoadingSoFast({
                 boxColor: '#123456',

--- a/example/example.html
+++ b/example/example.html
@@ -23,8 +23,8 @@
             <img src="sloth.jpg" alt="http://www.wisegeek.com/what-are-the-main-components-of-a-sloth-diet.htm#sloth-in-tree-showing-claws" />
         </div>
 
-        <script type="text/javascript" src="../comcastify.js"></script>
-        <script type="text/javascript">
+        <script src="../comcastify.js"></script>
+        <script>
 
             window.onload = comcastifyjs.fixMyImagesLoadingSoFast({
                 boxColor: '#123456',


### PR DESCRIPTION
Simple change: unnecessary 'type="text/javascript"' in the example HTML code <script> tags.

![comcastify pull request](https://cloud.githubusercontent.com/assets/5909572/4330934/52e64858-3fba-11e4-9de9-15f3e88f4f9a.png)
